### PR TITLE
Replace loops with iterators and chain arc vectors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use geo::{map_coords::MapCoordsInplace, LineString, Point, Polygon};
 use geographiclib_rs::{DirectGeodesic, Geodesic};
 use geojson::GeoJson;
 use std::convert::TryInto;
+use std::f64::consts::PI;
 use std::{default::Default, iter::FromIterator};
 
 // use std::path::PathBuf;
@@ -138,22 +139,27 @@ fn makecircle(
     num_vertices: usize,
     projected: bool,
 ) -> Polygon<f64> {
-    let mut circle_points = Vec::new();
-    if projected {
-        for i in 0..num_vertices {
-            let angle: f64 = 2.0 * std::f64::consts::PI / (num_vertices as f64) * (i as f64);
-            let x = centerpoint.x() + radius * angle.cos();
-            let y = centerpoint.y() + radius * angle.sin();
-            circle_points.push(Point::new(x, y));
-        }
+    let circle_points: Vec<Point<f64>> = if projected {
+        (0..num_vertices)
+            .enumerate()
+            .map(|(idx, _)| {
+                let angle: f64 = 2.0 * PI / (num_vertices as f64) * (idx as f64);
+                let x = centerpoint.x() + radius * angle.cos();
+                let y = centerpoint.y() + radius * angle.sin();
+                Point::new(x, y)
+            })
+            .collect()
     } else {
         let crs = Geodesic::wgs84();
-        for i in 0..num_vertices {
-            let angle: f64 = 360.0 / (num_vertices as f64) * (i as f64);
-            let (y, x) = crs.direct(centerpoint.y(), centerpoint.x(), angle, radius * 1000.0);
-            circle_points.push(Point::new(x, y));
-        }
-    }
+        (0..num_vertices)
+            .enumerate()
+            .map(|(idx, _)| {
+                let angle: f64 = 360.0 / (num_vertices as f64) * (idx as f64);
+                let (y, x) = crs.direct(centerpoint.y(), centerpoint.x(), angle, radius * 1000.0);
+                Point::new(x, y)
+            })
+            .collect()
+    };
     Polygon::new(LineString::from(circle_points), vec![])
 }
 
@@ -167,9 +173,6 @@ fn clockpoly(
     seg: usize,
     projected: bool,
 ) -> Polygon<f64> {
-    let mut arc_outer = Vec::new();
-    let mut arc_inner = Vec::new();
-
     // Sequence of vertices
     // in R round(seq(from, to, length.out = num_segments))
     // Number of vertices per segment
@@ -180,44 +183,59 @@ fn clockpoly(
     let to_iterator = 1 + (seg + 1) * nv;
     // Angle offset so first segment is North
     let o = std::f64::consts::PI / (num_segments as f64);
-    if projected {
-        for i in from_iterator..to_iterator {
-            let angle: f64 = 2.0 * std::f64::consts::PI / (nc as f64) * (i as f64) + o;
-            let x = centerpoint.x() + radius_outer * angle.sin();
-            let y = centerpoint.y() + radius_outer * angle.cos();
-            arc_outer.push(Point::new(x, y));
-        }
-        for i in (from_iterator..to_iterator).rev() {
-            let angle: f64 = 2.0 * std::f64::consts::PI / (nc as f64) * (i as f64) + o;
-            let x = centerpoint.x() + radius_inner * angle.sin();
-            let y = centerpoint.y() + radius_inner * angle.cos();
-            arc_inner.push(Point::new(x, y));
-        }
+    let arcs: Vec<Point<f64>> = if projected {
+        (from_iterator..to_iterator)
+            .enumerate()
+            .map(|(idx, _)| {
+                let angle: f64 = 2.0 * std::f64::consts::PI / (nc as f64) * (idx as f64) + o;
+                let x = centerpoint.x() + radius_outer * angle.sin();
+                let y = centerpoint.y() + radius_outer * angle.cos();
+                Point::new(x, y)
+            })
+            .chain(
+                (from_iterator..to_iterator)
+                    .rev()
+                    .enumerate()
+                    .map(|(idx, _)| {
+                        let angle: f64 =
+                            2.0 * std::f64::consts::PI / (nc as f64) * (idx as f64) + o;
+                        let x = centerpoint.x() + radius_inner * angle.sin();
+                        let y = centerpoint.y() + radius_inner * angle.cos();
+                        Point::new(x, y)
+                    }),
+            )
+            .collect()
     } else {
         let crs = Geodesic::wgs84();
-        for i in from_iterator..to_iterator {
-            let angle: f64 = 360.0 / (nc as f64) * (i as f64) + o;
-            let (y, x) = crs.direct(
-                centerpoint.y(),
-                centerpoint.x(),
-                angle,
-                radius_outer * 1000.0,
-            );
-            arc_outer.push(Point::new(x, y));
-        }
-        for i in (from_iterator..to_iterator).rev() {
-            let angle: f64 = 360.0 / (nc as f64) * (i as f64) + o;
-            let (y, x) = crs.direct(
-                centerpoint.y(),
-                centerpoint.x(),
-                angle,
-                radius_inner * 1000.0,
-            );
-            arc_inner.push(Point::new(x, y));
-        }
-    }
-
-    let arcs = [arc_outer, arc_inner].concat();
+        (from_iterator..to_iterator)
+            .enumerate()
+            .map(|(idx, _)| {
+                let angle: f64 = 360.0 / (nc as f64) * (idx as f64) + o;
+                let (y, x) = crs.direct(
+                    centerpoint.y(),
+                    centerpoint.x(),
+                    angle,
+                    radius_outer * 1000.0,
+                );
+                Point::new(x, y)
+            })
+            .chain(
+                (from_iterator..to_iterator)
+                    .rev()
+                    .enumerate()
+                    .map(|(idx, _)| {
+                        let angle: f64 = 360.0 / (nc as f64) * (idx as f64) + o;
+                        let (y, x) = crs.direct(
+                            centerpoint.y(),
+                            centerpoint.x(),
+                            angle,
+                            radius_inner * 1000.0,
+                        );
+                        Point::new(x, y)
+                    }),
+            )
+            .collect()
+    };
     Polygon::new(LineString::from(arcs), vec![])
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ fn arcpoints_geodesic(
     crs: &Geodesic,
     num_circles: usize,
     idx: usize,
-    o: f64,
+    angular_offset: f64,
     centerpoint: Point<f64>,
     radius: f64,
 ) -> Point<f64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,7 @@ pub fn clockboard(
                 };
                 let num_segs = if idx == 0 { 1 } else { params.num_segments };
                 (0..num_segs)
-                    .enumerate()
-                    .map(|(jdx, _)| {
+                    .map(|jdx| {
                         if idx != 0 {
                             clockpoly(
                                 centerpoint,
@@ -173,8 +172,7 @@ fn makecircle(
 ) -> Polygon<f64> {
     let circle_points: Vec<Point<f64>> = if projected {
         (0..num_vertices)
-            .enumerate()
-            .map(|(idx, _)| {
+            .map(|idx| {
                 let angle: f64 = 2.0 * PI / (num_vertices as f64) * (idx as f64);
                 let x = centerpoint.x() + radius * angle.cos();
                 let y = centerpoint.y() + radius * angle.sin();
@@ -184,8 +182,7 @@ fn makecircle(
     } else {
         let crs = Geodesic::wgs84();
         (0..num_vertices)
-            .enumerate()
-            .map(|(idx, _)| {
+            .map(|idx| {
                 let angle: f64 = 360.0 / (num_vertices as f64) * (idx as f64);
                 let (y, x) = crs.direct(centerpoint.y(), centerpoint.x(), angle, radius * 1000.0);
                 Point::new(x, y)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,27 +217,21 @@ fn clockpoly(
     let o = std::f64::consts::PI / (num_segments as f64);
     let arcs: Vec<Point<f64>> = if projected {
         (from_iterator..to_iterator)
-            .enumerate()
-            .map(|(idx, _)| arcpoints(nc, idx, o, centerpoint, radius_outer))
+            .map(|idx| arcpoints(nc, idx, o, centerpoint, radius_outer))
             .chain(
                 (from_iterator..to_iterator)
                     .rev()
-                    .enumerate()
-                    .map(|(idx, _)| arcpoints(nc, idx, o, centerpoint, radius_inner)),
+                    .map(|idx| arcpoints(nc, idx, o, centerpoint, radius_inner)),
             )
             .collect()
     } else {
         let crs = Geodesic::wgs84();
         (from_iterator..to_iterator)
-            .enumerate()
-            .map(|(idx, _)| arcpoints_geodesic(&crs, nc, idx, o, centerpoint, radius_outer))
+            .map(|idx| arcpoints_geodesic(&crs, nc, idx, o, centerpoint, radius_outer))
             .chain(
                 (from_iterator..to_iterator)
                     .rev()
-                    .enumerate()
-                    .map(|(idx, _)| {
-                        arcpoints_geodesic(&crs, nc, idx, o, centerpoint, radius_inner)
-                    }),
+                    .map(|idx| arcpoints_geodesic(&crs, nc, idx, o, centerpoint, radius_inner)),
             )
             .collect()
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,11 +225,9 @@ fn clockpoly(
         let crs = Geodesic::wgs84();
         (from_iterator..to_iterator)
             .map(|idx| arcpoints_geodesic(&crs, nc, idx, angular_offset, centerpoint, radius_outer))
-            .chain(
-                (from_iterator..to_iterator)
-                    .rev()
-                    .map(|idx| arcpoints_geodesic(&crs, nc, idx, angular_offset, centerpoint, radius_inner)),
-            )
+            .chain((from_iterator..to_iterator).rev().map(|idx| {
+                arcpoints_geodesic(&crs, nc, idx, angular_offset, centerpoint, radius_inner)
+            }))
             .collect()
     };
     Polygon::new(LineString::from(arcs), vec![])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,11 @@ impl Default for Params {
 fn arcpoints(
     num_circles: usize,
     idx: usize,
-    o: f64,
+    angular_offset: f64,
     centerpoint: Point<f64>,
     radius: f64,
 ) -> Point<f64> {
-    let angle: f64 = 2.0 * PI / (num_circles as f64) * (idx as f64) + o;
+    let angle: f64 = 2.0 * PI / (num_circles as f64) * (idx as f64) + angular_offset;
     let x = centerpoint.x() + radius * angle.sin();
     let y = centerpoint.y() + radius * angle.cos();
     Point::new(x, y)
@@ -85,7 +85,7 @@ fn arcpoints_geodesic(
     centerpoint: Point<f64>,
     radius: f64,
 ) -> Point<f64> {
-    let angle: f64 = 360.0 / (num_circles as f64) * (idx as f64) + o;
+    let angle: f64 = 360.0 / (num_circles as f64) * (idx as f64) + angular_offset;
     let (y, x) = crs.direct(centerpoint.y(), centerpoint.x(), angle, radius * 1000.0);
     Point::new(x, y)
 }
@@ -211,20 +211,20 @@ fn clockpoly(
     let from_iterator = seg * nv;
     let to_iterator = 1 + (seg + 1) * nv;
     // Angle offset so first segment is North
-    let o = std::f64::consts::PI / (num_segments as f64);
+    let angular_offset = std::f64::consts::PI / (num_segments as f64);
     let arcs: Vec<Point<f64>> = if projected {
         (from_iterator..to_iterator)
             .map(|idx| arcpoints(nc, idx, o, centerpoint, radius_outer))
             .chain(
                 (from_iterator..to_iterator)
                     .rev()
-                    .map(|idx| arcpoints(nc, idx, o, centerpoint, radius_inner)),
+                    .map(|idx| arcpoints(nc, idx, angular_offset, centerpoint, radius_inner)),
             )
             .collect()
     } else {
         let crs = Geodesic::wgs84();
         (from_iterator..to_iterator)
-            .map(|idx| arcpoints_geodesic(&crs, nc, idx, o, centerpoint, radius_outer))
+            .map(|idx| arcpoints_geodesic(&crs, nc, idx, angular_offset, centerpoint, radius_outer))
             .chain(
                 (from_iterator..to_iterator)
                     .rev()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ fn clockpoly(
     let angular_offset = std::f64::consts::PI / (num_segments as f64);
     let arcs: Vec<Point<f64>> = if projected {
         (from_iterator..to_iterator)
-            .map(|idx| arcpoints(nc, idx, o, centerpoint, radius_outer))
+            .map(|idx| arcpoints(nc, idx, angular_offset, centerpoint, radius_outer))
             .chain(
                 (from_iterator..to_iterator)
                     .rev()
@@ -228,7 +228,7 @@ fn clockpoly(
             .chain(
                 (from_iterator..to_iterator)
                     .rev()
-                    .map(|idx| arcpoints_geodesic(&crs, nc, idx, o, centerpoint, radius_inner)),
+                    .map(|idx| arcpoints_geodesic(&crs, nc, idx, angular_offset, centerpoint, radius_inner)),
             )
             .collect()
     };


### PR DESCRIPTION
Rather than manually looping and indexing, we can combine an iterator
with a `map()`. This has the advantage of removing mutable variables,
removing re-allocations on `push()`,  allowing the compiler to elide bounds checks (potentially giving
speedups), and being a bit less error prone.

We can combine the above with the `chain()` method when building arcs,
which allows us to avoid allocating two vectors and then combining
them into a third; it's possible that the compiler can optimise this
away, but with this approach we don't need to take the chance: using
`chain()` allows us to perform a single allocation.

We're also leveraging Rust's expression-oriented nature here, allowing
constructions like:

`let foo = if { //statement } else { //alternate statement };`

again allowing us to avoid defining `foo` twice.