### PR TITLE
Add an optional worldpop raster layer. Fixes #49

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -52,6 +52,14 @@
 				zoomOffset: -1
 			}).addTo(map);
 
+			// Add an optional raster layer for population
+			var worldpop = L.tileLayer('https://ogc.worldpop.org/geoserver/gwc/service/tms/1.0.0/wpGlobal%3Appp_2020@EPSG%3A900913@png/{z}/{x}/{-y}.png', {
+				tms: true,
+				opacity: 0.5,
+				maxNativeZoom: 11
+			});
+			L.control.layers(null, { "<a href='https://www.worldpop.org' target='_blank' title='Only available when zoomed out'>WorldPop 2020</a>": worldpop }, { collapsed: false }).addTo(map);
+
 			// Create a draggable marker representing the clockboard's center.
 			var marker = L.marker([30.2711286, -97.7436995], {
 				draggable: true,


### PR DESCRIPTION
![screencast](https://user-images.githubusercontent.com/1664407/127812694-c3f20a22-dcc5-4afd-9a9c-5e2fbfb8cffb.gif)
It'd be nice to display the less granular tile when zoomed in and just stretch it, but not sure how to make that work.

Super straightforward use of https://leafletjs.com/examples/layers-control/